### PR TITLE
Update Electron to v0.34 which ships with Node.js 4.1.1

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,7 +67,7 @@ module.exports = function(grunt) {
           dir             : '.',
           out             : 'dist',
           icon            : 'cumulus.icns',
-          version         : '0.30.2',
+          version         : '0.34.0',
           platform        : 'darwin',
           arch            : 'x64',
           // ignore          : 'node_modules/',

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ mb.on('ready', function() {
    * register Cumulus protocol
    */
   var protocol = require('protocol')
-  protocol.registerProtocol('cumulus', function(req) {
+  protocol.registerHttpProtocol('cumulus', function(req) {
 
     // parse access token
     var hash  = url.parse(req.url).hash.substr(1)


### PR DESCRIPTION
Not sure if this is something high on your priority list but already had a more recent version of `electron-prebuilt` installed and figured I'd take a crack at updating the dependency. Seems easy enough. I did a fair bit of testing, but let me know if there's anything else that needs to be addressed. Awesome project BTW. Thanks for putting it out there.