### PR TITLE
Add repo and license information

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
       "envify"
     ]
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gillesdemey/Cumulus"
+  },
+  "license": "MIT",
   "dependencies": {
     "classnames": "^1.2.2",
     "lodash": "^3.8.0",


### PR DESCRIPTION
Removes the following warnings from `npm install`:

<img width="440" alt="screen shot 2015-10-30 at 5 47 11 pm" src="https://cloud.githubusercontent.com/assets/432489/10859732/47bdd978-7f2e-11e5-9b4e-354db085c334.png">