### PR TITLE
Do not break on artwork. Fetch any available.

### DIFF
--- a/app/js/components/PlaylistListItem.js
+++ b/app/js/components/PlaylistListItem.js
@@ -41,7 +41,18 @@ var PlaylistListItem = React.createClass({
 
   render: function() {
 
-    var cover = this.props.playlist.artwork_url || this.props.tracks[0].artwork_url
+    var cover = this.props.playlist.artwork_url
+    if (!cover) {
+      var artwork_from_tracks = this.props.tracks
+        .filter(function(track) {
+          return track.artwork_url != undefined
+        })
+        .map(function(track) {
+          return track.artwork_url
+        })
+
+      cover = artwork_from_tracks.shift()
+    }
 
     var audio  = this.props.currentAudio
     var mine   = _.isEqual(this.props.tracks, playlistStore.getPlaylist())


### PR DESCRIPTION
Dirty fix for issue #42 
It allows to load empty playlist (possibly unwanted), but do not break the Cumulus.
Additionally it fetches first artwork from any track.
Empty playlist seen on first position in list.

<img width="919" alt="screen shot 2016-03-03 at 15 53 54" src="https://cloud.githubusercontent.com/assets/2324400/13498331/bdeeef14-e159-11e5-89a5-d02cf1ee9b1a.png">

