### PR TITLE
Switch off notifications sound

### DIFF
--- a/app/js/stores/currentTrackStore.js
+++ b/app/js/stores/currentTrackStore.js
@@ -13,8 +13,9 @@ var _audio = new Audio() // Current audio element
 function _showNotification(track) {
   if (document.visibilityState !== 'hidden') return
   new window.Notification(track.user.username, {
-    body : track.title,
-    icon : track.artwork_url,
+    body   : track.title,
+    icon   : track.artwork_url,
+    silent : true
   })
 }
 


### PR DESCRIPTION
Notifications don't make any sound or vibrations when tracks changes

Basically, this pull request addresses following issue https://github.com/gillesdemey/Cumulus/issues/53 but it is not exposed as an option in settings. It doesn't make any sense to add such a setting for alerts to make sound when track changes as no music applications (i.e., iTunes) behave in such a way.

Feel free to comment :wink: 