### PR TITLE
update electron to 1.1.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,7 +67,7 @@ module.exports = function(grunt) {
           dir             : '.',
           out             : 'dist',
           icon            : 'cumulus.icns',
-          version         : '0.37.8',
+          version         : '1.1.0',
           platform        : 'darwin',
           arch            : 'x64',
           prune           : true,

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Remote          = window.require('remote');
+var Remote          = window.require('electron').remote; // hack for browserify
 
 var React           = require('react');
 var Router          = require('react-router');

--- a/app/js/components/mediaPlayer.js
+++ b/app/js/components/mediaPlayer.js
@@ -9,12 +9,14 @@ var github            = require('../utils/github')
 var classNames        = require('classnames')
 var _                 = require('lodash')
 
-var remote            = window.require('remote')
-var Menu              = remote.require('menu')
-var MenuItem          = remote.require('menu-item')
-var pjson             = remote.require('./package.json')
-var app               = remote.require('app')
-var dialog            = remote.require('dialog');
+var electron          = window.require('electron')
+var shell             = electron.shell
+var remote            = electron.remote; // hack for browserify
+var Menu              = remote.Menu
+var MenuItem          = remote.MenuItem
+var pjson             = remote.require('./package.json') // based on index.js directory
+var app               = remote.app
+var dialog            = remote.dialog
 var icon              = remote.nativeImage.createFromPath(app.getAppPath() + '/cumulus.png');
 
 function getStateFromStores() {
@@ -121,7 +123,7 @@ var MediaPlayer = React.createClass({
   },
 
   openExternal: function(url) {
-    remote.require('shell').openExternal(url)
+    shell.openExternal(url)
   },
 
   about: function() {
@@ -151,7 +153,7 @@ var MediaPlayer = React.createClass({
 
       dialog.showMessageBox(options, function(buttonId) {
         if(buttonId === 0) {
-          remote.require('shell').openExternal(github.getRepoUrl() + '/releases/latest')
+          shell.openExternal(github.getRepoUrl() + '/releases/latest')
         }
       })
     })
@@ -170,7 +172,7 @@ var MediaPlayer = React.createClass({
   },
 
   quit: function() {
-    remote.require('app').quit()
+    remote.app.quit()
   },
 
   render: function() {

--- a/app/js/utils/github.js
+++ b/app/js/utils/github.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var remote            = window.require('remote');
+var remote            = window.require('electron').remote; // hack for browserify
 var pjson             = remote.require('./package.json');
 var rp                = window.require('request-promise')
 var _                 = require('lodash')

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 'use strict';
 
-var App            = require('app')
-var BrowserWindow  = require('browser-window')
-var globalShortcut = require('global-shortcut')
-var Menu           = require('menu')
+var electron       = require('electron')
+var App            = electron.app
+var BrowserWindow  = electron.BrowserWindow
+var globalShortcut = electron.globalShortcut
+var Menu           = electron.Menu
 
 var url            = require('url')
 var querystring    = require('querystring')
@@ -64,7 +65,7 @@ mb.on('ready', function() {
   /**
    * register Cumulus protocol
    */
-  var protocol = require('protocol')
+  var protocol = electron.protocol
   protocol.registerHttpProtocol('cumulus', function(req) {
 
     var uri = url.parse(req.url)

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var app = require('app');
+var app = require('electron').app;
 var fs  = require('fs');
 
 var CONFIG_FILE = app.getPath('userData') + '/config.json';

--- a/lib/menu.js
+++ b/lib/menu.js
@@ -1,4 +1,4 @@
-var Menu = require('menu')
+var Menu = require('electron').Menu
 
 var template = [
   {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "classnames": "^1.2.2",
     "lodash": "^3.8.0",
     "mcfly": "0.0.10",
-    "menubar": "^4.0.2",
+    "menubar": "^4.1.1",
     "moment": "^2.10.3",
     "react": "^0.13.2",
     "react-router": "^0.13.3",


### PR DESCRIPTION
When trying to develop Cumulus, I couldn't run this app because the newest `electron-prebuilt` has destructive changes in codes.

notice: I found that a version of `grunt-electron` remain ver 1.0.  Do you have any reason why don't you upgrade the package?