### PR TITLE
Initialize window after window is created

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,11 +92,6 @@ mb.on('ready', function() {
     mb.window.webContents.send('GlobalShortcuts', accelerator)
   }
 
-  function _sendWindowEvent(name) {
-    if (!mb.window) return
-    mb.window.webContents.send('WindowEvent', name)
-  }
-
   globalShortcut.register('MediaPlayPause', function() {
     _sendGlobalShortcut('MediaPlayPause')
   })
@@ -113,24 +108,29 @@ mb.on('ready', function() {
     _sendGlobalShortcut('SoundCloudLikeTrack')
   })
 
-  mb.on('after-create-window', function() {
+})
 
-    if (!debug) {
-      mb.window.setSize(320, 500)
-      mb.window.setMaximumSize(320, 600)
-      mb.window.setMinimumSize(320, 400)
-    } else {
-      mb.window.setSize(620, 700)
-      mb.window.setMaximumSize(1220, 800)
-      mb.window.setMinimumSize(620, 600)
-    }
+mb.on('after-create-window', function() {
 
-    mb.window.setResizable(true)
-    mb.window.loadURL('file://' + __dirname + '/app/index.html')
-    mb.window.on('focus', function() { _sendWindowEvent('focus') })
-    if (debug) {
-      mb.window.openDevTools()
-    }
-  })
+  function _sendWindowEvent(name) {
+    if (!mb.window) return
+    mb.window.webContents.send('WindowEvent', name)
+  }
 
+  if (!debug) {
+    mb.window.setSize(320, 500)
+    mb.window.setMaximumSize(320, 600)
+    mb.window.setMinimumSize(320, 400)
+  } else {
+    mb.window.setSize(620, 700)
+    mb.window.setMaximumSize(1220, 800)
+    mb.window.setMinimumSize(620, 600)
+  }
+
+  mb.window.setResizable(true)
+  mb.window.loadURL('file://' + __dirname + '/app/index.html')
+  mb.window.on('focus', function() { _sendWindowEvent('focus') })
+  if (debug) {
+    mb.window.openDevTools()
+  }
 })

--- a/index.js
+++ b/index.js
@@ -43,25 +43,6 @@ mb.on('ready', function() {
     loginWindow.loadURL('https://soundcloud.com/connect?client_id=f17c1d67b83c86194fad2b1948061c9e&response_type=token&scope=non-expiring&display=next&redirect_uri=cumulus://oauth/callback')
   }
 
-  function initialize() {
-    if (!debug) {
-      mb.window.setSize(320, 500)
-      mb.window.setMaximumSize(320, 600)
-      mb.window.setMinimumSize(320, 400)
-    } else {
-      mb.window.setSize(620, 700)
-      mb.window.setMaximumSize(1220, 800)
-      mb.window.setMinimumSize(620, 600)
-    }
-
-    mb.window.setResizable(true)
-    mb.window.loadURL('file://' + __dirname + '/app/index.html')
-    mb.window.on('focus', function() { _sendWindowEvent('focus') })
-    if (debug) {
-      mb.window.openDevTools()
-    }
-  }
-
   /**
    * register Cumulus protocol
    */
@@ -84,7 +65,6 @@ mb.on('ready', function() {
             loginWindow.removeListener('close', App.quit)
             loginWindow.close()
           }
-          initialize()
         })
         break
 
@@ -103,9 +83,7 @@ mb.on('ready', function() {
     if (err)
       throw err
 
-    if (typeof value !== 'undefined' && value !== null)
-      initialize()
-    else
+    if (typeof value === 'undefined' || value === null)
       doLogin()
   })
 
@@ -135,5 +113,24 @@ mb.on('ready', function() {
     _sendGlobalShortcut('SoundCloudLikeTrack')
   })
 
+  mb.on('after-create-window', function() {
+
+    if (!debug) {
+      mb.window.setSize(320, 500)
+      mb.window.setMaximumSize(320, 600)
+      mb.window.setMinimumSize(320, 400)
+    } else {
+      mb.window.setSize(620, 700)
+      mb.window.setMaximumSize(1220, 800)
+      mb.window.setMinimumSize(620, 600)
+    }
+
+    mb.window.setResizable(true)
+    mb.window.loadURL('file://' + __dirname + '/app/index.html')
+    mb.window.on('focus', function() { _sendWindowEvent('focus') })
+    if (debug) {
+      mb.window.openDevTools()
+    }
+  })
 
 })


### PR DESCRIPTION
This prevents race conditions when `mb.preloadWindow` is set to `false`.

This would allow to disable window rendering if the user is not logged in yet.